### PR TITLE
Link to code of conduct from README for better visibility

### DIFF
--- a/CONTRIBUTING.md.template
+++ b/CONTRIBUTING.md.template
@@ -1,6 +1,10 @@
 We love pull requests from everyone. By participating in this project, you
 agree to abide by the thoughtbot [code of conduct].
 
+We expect everyone to follow the code of conduct
+in all thoughtbot open source codebases,
+issue trackers, IRC channel, group chat, and mailing lists.
+
 [code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ Contributing
 See the [CONTRIBUTING] document.
 Thank you, [contributors]!
 
+We expect all contributors to follow thoughtbot's [code of conduct].
+
 [CONTRIBUTING]: CONTRIBUTING.md
 [contributors]: https://github.com/thoughtbot/templates/graphs/contributors
+[code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
 
 Need Help?
 ----------

--- a/README.md.template
+++ b/README.md.template
@@ -15,8 +15,11 @@ Contributing
 See the [CONTRIBUTING] document.
 Thank you, [contributors]!
 
+We expect all contributors to follow thoughtbot's [code of conduct].
+
 [CONTRIBUTING]: CONTRIBUTING.md
 [contributors]: https://github.com/thoughtbot/$(REPO_NAME)/graphs/contributors
+[code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
 
 Need Help?
 ----------


### PR DESCRIPTION
I imagine that many contributors don't actually read the CONTRIBUTING document.
Also, we want everyone - not just contributors -
to know about the CoC so they can properly report incidents, etc.
