### PR TITLE
Replace in-line style guidelines with link

### DIFF
--- a/CONTRIBUTING.md.template
+++ b/CONTRIBUTING.md.template
@@ -1,53 +1,32 @@
-We love pull requests from everyone. By participating in this project, you
-agree to abide by the thoughtbot [code of conduct].
+# Contributing
+
+We love pull requests from everyone.
+By participating in this project,
+you agree to abide by the thoughtbot [code of conduct].
+
+[code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
 
 We expect everyone to follow the code of conduct
 anywhere in thoughtbot's project codebases,
 issue trackers, chatrooms, and mailing lists.
 
-[code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
-
-## Dependencies
-
 $(INSTALL_DEPENDENCIES)
 
-## Contributing
+Fork the repo.
 
-1. Fork the repo.
+Make sure the tests pass:
 
-2. Run the tests. We only take pull requests with passing tests, and it's great
-to know that you have a clean slate: $(TEST_RUNNER)
+    $(TEST_RUNNER)
 
-3. Add a test for your change. Only refactoring and documentation changes
-require no new tests. If you are adding functionality or fixing a bug, we need
-a test!
+Make your change, with new passing tests. Follow the [style guide][style].
 
-4. Make the test pass.
+[style]: https://github.com/thoughtbot/guides/tree/master/style
 
-5. Push to your fork and submit a pull request.
+Push to your fork. Write a [good commit message][commit]. Submit a pull request.
 
+[commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 
-At this point you're waiting on us. We like to at least comment on, if not
-accept, pull requests within three business days (and, typically, one business
-day). We may suggest some changes or improvements or alternatives.
-
-Some things that will increase the chance that your pull request is accepted,
-$(FOR RUBY:
-taken straight from the Ruby on Rails guide:
-
-* Use Rails idioms and helpers
-* Include tests that fail without your code, and pass with it
-* Update the documentation, the surrounding one, examples elsewhere, guides,
-  whatever is affected by your contribution
-
-Syntax:
-
-* Two spaces, no tabs.
-* No trailing whitespace. Blank lines should not have any space.
-* Prefer &&/|| over and/or.
-* MyClass.my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
-* a = b and not a=b.
-* Follow the conventions you see used in the source already.
-)
-
-And in case we didn't emphasize it enough: we love tests!
+Others will give constructive feedback.
+This is a time for discussion and improvements,
+and making the necessary changes will be required before we can
+merge the contribution.


### PR DESCRIPTION
- Use shorter sentences to describe each step.
- Begin document with h1 header to pass Markdown linting.

https://github.com/thoughtbot/templates/issues/4
