### PR TITLE
Use consistent Markdown style

### DIFF
--- a/CONTRIBUTING.md.template
+++ b/CONTRIBUTING.md.template
@@ -4,7 +4,7 @@ We love pull requests from everyone.
 By participating in this project,
 you agree to abide by the thoughtbot [code of conduct].
 
-[code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
+  [code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
 
 We expect everyone to follow the code of conduct
 anywhere in thoughtbot's project codebases,
@@ -20,11 +20,11 @@ Make sure the tests pass:
 
 Make your change, with new passing tests. Follow the [style guide][style].
 
-[style]: https://github.com/thoughtbot/guides/tree/master/style
+  [style]: https://github.com/thoughtbot/guides/tree/master/style
 
 Push to your fork. Write a [good commit message][commit]. Submit a pull request.
 
-[commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+  [commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 
 Others will give constructive feedback.
 This is a time for discussion and improvements,

--- a/README.md
+++ b/README.md
@@ -1,48 +1,32 @@
-Templates
-==========
+# Templates
 
 Use the files in this repo as templates for your projects. Be sure to read
 through them, understand their implications, and fill in the placeholders.
 
-Usage
------
+## Usage
 
 ```sh
 cp templates/README.md.template my-awesome-project/README.md
 $VISUAL my-awesome-project/README.md
 ```
 
-Contributing
-------------
+## Contributing
 
 See the [CONTRIBUTING] document.
 Thank you, [contributors]!
 
-We expect all contributors to follow thoughtbot's [code of conduct].
+  [CONTRIBUTING]: CONTRIBUTING.md
+  [contributors]: https://github.com/thoughtbot/templates/graphs/contributors
 
-[CONTRIBUTING]: CONTRIBUTING.md
-[contributors]: https://github.com/thoughtbot/templates/graphs/contributors
-[code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
+## License
 
-Need Help?
-----------
-
-We offer 1-on-1 coaching. [Get in touch] if you'd like to learn more about
-starting, maintaining, and contributing to an open source project.
-
-[Get in touch]: http://coaching.thoughtbot.com/rails/?utm_source=github
-
-License
--------
-
-Open source templates are Copyright (c) 2015 thoughtbot, inc. It contains free
-software that may be redistributed under the terms specified in the [LICENSE]
-file.
+Open source templates are Copyright (c) 2015 thoughtbot, inc.
+It contains free software that may be redistributed
+under the terms specified in the [LICENSE] file.
 
 [LICENSE]: /LICENSE
 
-About
------
+## About
 
 ![thoughtbot](https://thoughtbot.com/logo.png)
 
@@ -53,5 +37,5 @@ We love open source software!
 See [our other projects][community]
 or [hire us][hire] to help build your product.
 
-[community]: https://thoughtbot.com/community?utm_source=github
-[hire]: https://thoughtbot.com/hire-us?utm_source=github
+  [community]: https://thoughtbot.com/community?utm_source=github
+  [hire]: https://thoughtbot.com/hire-us?utm_source=github

--- a/README.md.template
+++ b/README.md.template
@@ -1,36 +1,28 @@
-$(PROJECT_NAME)
-===============
+# $(PROJECT_NAME)
 
 $(TEASER)
 
-Usage
------
+## Usage
 
 $(USAGE_INSTRUCTIONS)
 
-
-Contributing
-------------
+## Contributing
 
 See the [CONTRIBUTING] document.
 Thank you, [contributors]!
 
-We expect all contributors to follow thoughtbot's [code of conduct].
+  [CONTRIBUTING]: CONTRIBUTING.md
+  [contributors]: https://github.com/thoughtbot/$(REPO_NAME)/graphs/contributors
 
-[CONTRIBUTING]: CONTRIBUTING.md
-[contributors]: https://github.com/thoughtbot/$(REPO_NAME)/graphs/contributors
-[code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
+## License
 
-License
--------
+$(PROJECT_NAME) is Copyright (c) 2015 thoughtbot, inc.
+It is free software, and may be redistributed
+under the terms specified in the [LICENSE] file.
 
-$(PROJECT_NAME) is Copyright (c) 2015 thoughtbot, inc. It is free software,
-and may be redistributed under the terms specified in the [LICENSE] file.
+  [LICENSE]: /LICENSE
 
-[LICENSE]: /LICENSE
-
-About
------
+## About
 
 $(PROJECT_NAME) is maintained by $(MAINTAINERS).
 
@@ -43,5 +35,5 @@ We love open source software!
 See [our other projects][community]
 or [hire us][hire] to help build your product.
 
-[community]: https://thoughtbot.com/community?utm_source=github
-[hire]: https://thoughtbot.com/hire-us?utm_source=github
+  [community]: https://thoughtbot.com/community?utm_source=github
+  [hire]: https://thoughtbot.com/hire-us?utm_source=github

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,17 +1,20 @@
 # Releasing
 
 1. Update version file accordingly.
-2. Update `NEWS.md` to reflect the changes since last release.
-3. Commit changes. There shouldn’t be code changes, and thus CI doesn’t need to
-   run, you can then add “[ci skip]” to the commit message.
-4. Tag the release: `git tag vVERSION`
-5. Push changes: `git push --tags`
-6. Build and publish:
+1. Update `NEWS.md` to reflect the changes since last release.
+1. Commit changes.
+   There shouldn't be code changes,
+   and thus CI doesn't need to run,
+   you can then add "[ci skip]" to the commit message.
+1. Tag the release: `git tag vVERSION`
+1. Push changes: `git push --tags`
+1. Build and publish:
 
-   ```bash
-   gem build doorkeeper.gemspec
-   gem push doorkeeper-*.gem
-   ```
+```bash
+gem build doorkeeper.gemspec
+gem push doorkeeper-*.gem
+```
 
-7. Announce the new release, making sure to say “thank you” to the contributors
+1. Announce the new release,
+   making sure to say "thank you" to the contributors
    who helped shape this version!


### PR DESCRIPTION
- `#` and `##` headings.
- Indented `[]:` link references.
- Use `1.` numerical style to pass Markdown Lint.
- Remove coaching CTA, as it's not really being offered anymore.
- Remove duplicate code of conduct reference
  (it's referenced prominently in CONTRIBUTING.md).
