### PR TITLE
RELEASING document adjustments

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,12 +9,13 @@
 1. Tag the release: `git tag vVERSION`
 1. Push changes: `git push --tags`
 1. Build and publish:
+  ```bash
+  gem build project-name.gemspec
+  gem push project-name-*.gem
+  ```
 
-```bash
-gem build doorkeeper.gemspec
-gem push doorkeeper-*.gem
-```
-
+1. Add a new GitHub release using the recent `NEWS.md` as the content. Sample
+   URL: https://github.com/thoughtbot/project-name/releases/new?tag=vVERSION
 1. Announce the new release,
    making sure to say "thank you" to the contributors
    who helped shape this version!


### PR DESCRIPTION
- Replace specific project name by a generic one
- Fix white space, so markdown renders the appropriate item number after
  the code sample
- Add GitHub release RELEASING step

<img width="935" alt="screen shot 2015-11-08 at 11 09 33 am" src="https://cloud.githubusercontent.com/assets/54260/11021242/37a764a0-8609-11e5-96d4-336477cf5d19.png">
