### PR TITLE
Add a code of conduct template

### DIFF
--- a/CODE_OF_CONDUCT.md.template
+++ b/CODE_OF_CONDUCT.md.template
@@ -1,0 +1,6 @@
+# Code of conduct
+
+By participating in this project, you agree to abide by the
+[thoughtbot code of conduct][1].
+
+[1]: https://thoughtbot.com/open-source-code-of-conduct


### PR DESCRIPTION
This is a link to our official open source code of conduct.

When the file named `CODE_OF_CONDUCT.md` exists in the project root,
GitHub will show a link to the file on the community profile page (e.g.
https://github.com/thoughtbot/rcm/community ).