### PR TITLE
Fix Markdown formatting

### DIFF
--- a/RELEASING.md.template
+++ b/RELEASING.md.template
@@ -7,14 +7,13 @@
    and thus CI doesn't need to run,
    you can then add "[ci skip]" to the commit message.
 1. Tag the release: `git tag -s vVERSION`
-  - We recommend the [_quick guide on how to sign a release_] from git ready.
+    - We recommend the [_quick guide on how to sign a release_] from git ready.
 1. Push changes: `git push --tags`
 1. Build and publish:
-  ```bash
-  gem build project-name.gemspec
-  gem push project-name-*.gem
-  ```
-
+    ```bash
+    gem build project-name.gemspec
+    gem push project-name-*.gem
+    ```
 1. Add a new GitHub release using the recent `NEWS.md` as the content. Sample
    URL: https://github.com/thoughtbot/project-name/releases/new?tag=vVERSION
 1. Announce the new release,


### PR DESCRIPTION
The list was not enumerating when rendered, because the indentation was only two spaces, not four.

## Before

(as seen on the thoughtbot/factory_bot_rails repo, which uses this template)
<img width="976" alt="screen shot 2019-02-26 at 11 11 09" src="https://user-images.githubusercontent.com/903327/53427701-6ce11700-39b7-11e9-90fb-2503fc2a3241.png">

## After

<img width="976" alt="screen shot 2019-02-26 at 11 11 20" src="https://user-images.githubusercontent.com/903327/53427710-70749e00-39b7-11e9-82c3-0704cee70b86.png">
