### PR TITLE
Adds additional Releasing steps

### DIFF
--- a/RELEASING.md.template
+++ b/RELEASING.md.template
@@ -1,11 +1,13 @@
 # Releasing
 
 1. Update version file accordingly.
+1. If necessary, install dependencies and update any version snapshot files (`Gemfile.lock`, etc)
 1. Update `NEWS.md` to reflect the changes since last release.
 1. Commit changes.
    There shouldn't be code changes,
    and thus CI doesn't need to run,
    you can then add "[ci skip]" to the commit message.
+1. Push the new commit
 1. Tag the release: `git tag -s vVERSION`
     - We recommend the [_quick guide on how to sign a release_] from git ready.
 1. Push changes: `git push --tags`


### PR DESCRIPTION
While following this process recently, we came across a couple of steps
that may be worth explicitly calling out.

This commit adds a step to update any dependencies, which may update a
corresponding version snapshot file. For a Ruby gem, this may update the
gem's version in `Gemfile.lock`.

This also adds a note that after committing your changes, you should
push that commit up. This is so the commit exists for the tag to
reference when the tag itself is pushed.