### PR TITLE
Create CODEOWNERS.template

### DIFF
--- a/CODEOWNERS.template
+++ b/CODEOWNERS.template
@@ -1,0 +1,15 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+# Global rule:
+* @$(GITHUB_USERNAME)


### PR DESCRIPTION
We have an experiment of using CODEOWNERS that seems like it is nearing a successful conclusion. https://github.com/thoughtbot/handbook/issues/2305

This adds a template for CODEOWNERS in preparation for that.