### PR TITLE
Remove year from license

### DIFF
--- a/LICENSE.template
+++ b/LICENSE.template
@@ -1,4 +1,4 @@
-Copyright (c) <year> <you> and thoughtbot, inc.
+Copyright (c) <you> and thoughtbot, inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
In an effort to be consistent with [curl, Rails, and others][1], we
remove the year from our license template. This ensures future projects
using this template aren't responsible for having to update the license
annually.

[1]: https://github.com/rails/rails/pull/47467
