### PR TITLE
Remove year from templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Thank you, [contributors]!
 
 ## License
 
-Open source templates are Copyright (c) 2020 thoughtbot, inc.
+Open source templates are Copyright (c) thoughtbot, inc.
 It contains free software that may be redistributed
 under the terms specified in the [LICENSE] file.
 

--- a/README.md.template
+++ b/README.md.template
@@ -16,7 +16,7 @@ Thank you, [contributors]!
 
 ## License
 
-$(PROJECT_NAME) is Copyright (c) 2017 thoughtbot, inc.
+$(PROJECT_NAME) is Copyright (c) thoughtbot, inc.
 It is free software, and may be redistributed
 under the terms specified in the [LICENSE] file.
 


### PR DESCRIPTION
In an effort to support #23, we remove all references to a specific year
from the README template, as well as the README itself.
