### PR TITLE
Fix path to logo

### DIFF
--- a/README.md.template
+++ b/README.md.template
@@ -26,7 +26,7 @@ under the terms specified in the [LICENSE] file.
 
 $(PROJECT_NAME) is maintained by $(MAINTAINERS).
 
-![thoughtbot](http://presskit.thoughtbot.com/images/thoughtbot-logo-for-readmes.svg)
+![thoughtbot](https://thoughtbot.com/brand_assets/93:44.svg)
 
 $(PROJECT_NAME) is maintained and funded by thoughtbot, inc.
 The names and logos for thoughtbot are trademarks of thoughtbot, inc.


### PR DESCRIPTION
The previous path was broken. This updates the `README.md.template` to
use the path that is currently in use in the `README.md`.
