### PR TITLE
Test workflow dispatch to update READMEs

### DIFF
--- a/.github/workflows/trigger-dynamic-readme-update.yaml
+++ b/.github/workflows/trigger-dynamic-readme-update.yaml
@@ -1,0 +1,20 @@
+name: trigger-dynamic-readme-update
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - templates/footer.md
+
+jobs:
+  trigger-workflow-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Dynamic READMEs to be updated with templates
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: update-templates
+          repo: thoughtbot/testing-reusable-repos
+          token: ${{ secrets.REPOSITORY_ACCESS_TOKEN }}
+          ref: "main"


### PR DESCRIPTION
When this repo updates the footer file template, we want to propagate the changes to all repos using the `dynamic-readme` workflow.

Trying this suggestion from @minaslater:
https://github.com/thoughtbot/templates/pull/28#issuecomment-1967273510