### PR TITLE
Add remaining repos to be updated when this workflow is triggered

### DIFF
--- a/.github/workflows/dynamic-readme-example.yaml
+++ b/.github/workflows/dynamic-readme-example.yaml
@@ -1,0 +1,17 @@
+name: update-templates
+
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-templates:
+    permissions:
+      contents: write
+      pull-requests: write
+      pages: write
+    uses: thoughtbot/templates/.github/workflows/dynamic-readme.yaml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trigger-dynamic-readme-update.yaml
+++ b/.github/workflows/trigger-dynamic-readme-update.yaml
@@ -14,7 +14,51 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        repository: [thoughtbot/high_voltage]
+        repository:
+          - thoughtbot/high_voltage
+          - thoughtbot/guides
+          - thoughtbot/administrate
+          - thoughtbot/shoulda-matchers
+          - thoughtbot/flightdeck
+          - thoughtbot/suspenders
+          - thoughtbot/shoulda-context
+          - thoughtbot/appraisal
+          - thoughtbot/clearance-i18n
+          - thoughtbot/gold_miner
+          - thoughtbot/capybara_accessibility_audit
+          - thoughtbot/upcase
+          - thoughtbot/ruby-science
+          - thoughtbot/terraform-flightdeck-aws-application
+          - thoughtbot/design-system
+          - thoughtbot/factory_bot_rails
+          - thoughtbot/bourbon
+          - thoughtbot/factory_bot
+          - thoughtbot/ember-cli-rails
+          - thoughtbot/dotfiles
+          - thoughtbot/terraform-ses-domain-identity
+          - thoughtbot/stylelint-config
+          - thoughtbot/cloudformation-terraform-state-backend
+          - thoughtbot/humid
+          - thoughtbot/clearance
+          - thoughtbot/griddler-sendgrid
+          - thoughtbot/terraform-aws-secrets
+          - thoughtbot/yuri-ita
+          - thoughtbot/paul_revere
+          - thoughtbot/terraform-eks-cicd
+          - thoughtbot/terraform-s3-bucket
+          - thoughtbot/terraform-route-53-delegated-subdomain
+          - thoughtbot/eslint-config
+          - thoughtbot/rcm
+          - thoughtbot/fishery
+          - thoughtbot/terrapin
+          - thoughtbot/shoulda
+          - thoughtbot/laptop
+          - thoughtbot/resolved
+          - thoughtbot/griddler
+          - thoughtbot/climate_control
+          - thoughtbot/Curry
+          - thoughtbot/croutons
+          - thoughtbot/parity
     steps:
       - name: Trigger Dynamic READMEs to be updated with templates
         uses: benc-uk/workflow-dispatch@v1

--- a/README.md
+++ b/README.md
@@ -10,13 +10,22 @@ cp templates/README.md.template my-awesome-project/README.md
 $VISUAL my-awesome-project/README.md
 ```
 
+### Dynamic content for the footer
+
+The [README.md.template](/README.md.template) includes a dynamic README
+content snippet. That means the footer will be rendered and updated automatically
+for you with the contents from the [templates footer](/templates/footer.md) file.
+
+To make it work, copy this [github workflow example](/.github/workflows/dynamic-readme-example.yaml)
+and rename it to `dynamic-readme`.
+
 ## Contributing
 
 See the [CONTRIBUTING] document.
 Thank you, [contributors]!
 
-  [CONTRIBUTING]: CONTRIBUTING.md
-  [contributors]: https://github.com/thoughtbot/templates/graphs/contributors
+[CONTRIBUTING]: CONTRIBUTING.md
+[contributors]: https://github.com/thoughtbot/templates/graphs/contributors
 
 ## License
 
@@ -26,16 +35,5 @@ under the terms specified in the [LICENSE] file.
 
 [LICENSE]: /LICENSE
 
-## About
-
-![thoughtbot](https://thoughtbot.com/thoughtbot-logo-for-readmes.svg)
-
-Templates are maintained and funded by thoughtbot, inc.
-The names and logos for thoughtbot are trademarks of thoughtbot, inc.
-
-We love open source software!
-See [our other projects][community]
-or [hire us][hire] to help build your product.
-
-  [community]: https://thoughtbot.com/community?utm_source=github
-  [hire]: https://thoughtbot.com/hire-us?utm_source=github
+<!-- START /templates/footer.md -->
+<!-- END /templates/footer.md -->

--- a/README.md
+++ b/README.md
@@ -10,14 +10,16 @@ cp templates/README.md.template my-awesome-project/README.md
 $VISUAL my-awesome-project/README.md
 ```
 
-### Dynamic content for the footer
+### Dynamic content rendering for the footer
 
 The [README.md.template](/README.md.template) includes a dynamic README
 content snippet. That means the footer will be rendered and updated automatically
-for you with the contents from the [templates footer](/templates/footer.md) file.
+for you with the contents from the [footer](/templates/footer.md) template.
 
-To make it work, copy this [github workflow example](/.github/workflows/dynamic-readme-example.yaml)
+To make it work when using the [README.md.template](/README.md.template):
+- copy the [github workflow example](/.github/workflows/dynamic-readme-example.yaml)
 and rename it to `dynamic-readme`.
+- add the repo path to the repository matrix in the [workflow dispatch](/.github/workflows/trigger-dynamic-readme-update.yaml).
 
 ## Contributing
 

--- a/README.md.template
+++ b/README.md.template
@@ -22,18 +22,5 @@ under the terms specified in the [LICENSE] file.
 
 [LICENSE]: /LICENSE
 
-## About
-
-$(PROJECT_NAME) is maintained by $(MAINTAINERS).
-
-![thoughtbot](https://thoughtbot.com/thoughtbot-logo-for-readmes.svg)
-
-$(PROJECT_NAME) is maintained and funded by thoughtbot, inc.
-The names and logos for thoughtbot are trademarks of thoughtbot, inc.
-
-We love open source software!
-See [our other projects][community]
-or [hire us][hire] to help build your product.
-
-[community]: https://thoughtbot.com/community?utm_source=github
-[hire]: https://thoughtbot.com/hire-us?utm_source=github
+<!-- START /templates/footer.md -->
+<!-- END /templates/footer.md -->


### PR DESCRIPTION
All of these repos have had the workflow and snippet added to them. This is the final step (I believe) missing to keep our repos in sync with the template.

Unfortunately, for this workflow to work, GitHub seems to need the repo list to be defined explicitly, instead of using `github.repository` or something else more generic.

Using a matrix, we can iterate over the repo list in the steps section. Not sure if there is a better way to do this, though.

### About the repos

I went through the most active repos. I only added the snippet and workflow to the projects that already have the footer/are not forked. Feel free to keep adding the [workflow + snippet](https://github.com/thoughtbot/climate_control/pull/56) to any missing project that you encounter.