### PR TITLE
Update dynamic README workflow to open a Pull Request

### DIFF
--- a/.github/workflows/dynamic-readme-example.yaml
+++ b/.github/workflows/dynamic-readme-example.yaml
@@ -1,7 +1,9 @@
 name: update-templates
 
-on: 
+on:
   push:
+    paths:
+      - README.md
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/dynamic-readme.yaml
+++ b/.github/workflows/dynamic-readme.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: documentation files updated [skip ci]"

--- a/.github/workflows/dynamic-readme.yaml
+++ b/.github/workflows/dynamic-readme.yaml
@@ -29,6 +29,24 @@ jobs:
             README.md
           committer_name: github-actions[bot]
           committer_email: github-actions[bot]@users.noreply.github.com
-          commit_message: 'docs: update readme file with markdown templates [skip ci]'
+          commit_message: "docs: update readme file with markdown templates [skip ci]"
+          confirm_and_push: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create pull request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "docs: documentation files updated [skip ci]"
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          signoff: false
+          branch: github-actions/repository-maintenance
+          delete-branch: true
+          title: "Automatically Generated: Update Dynamic Section in README"
+          body: |
+            This PR was automatically generated to update the dynamic section in the README file.
+            Whenever the README is updated, this workflow is triggered to dynamically render the snippet
+            used in the README.

--- a/README.md
+++ b/README.md
@@ -37,19 +37,5 @@ under the terms specified in the [LICENSE] file.
 
 [LICENSE]: /LICENSE
 
-<!-- START /templates/footer.md -->
-## About thoughtbot
-
-![thoughtbot](https://thoughtbot.com/thoughtbot-logo-for-readmes.svg)
-
-This repo is maintained and funded by thoughtbot, inc.
-The names and logos for thoughtbot are trademarks of thoughtbot, inc.
-
-We love open source software!
-See [our other projects][community].
-We are [available for hire][hire].
-
-[community]: https://thoughtbot.com/community?utm_source=github
-[hire]: https://thoughtbot.com/hire-us?utm_source=github
-
-<!-- END /templates/footer.md -->
+<!-- START templates/footer.md -->
+<!-- END templates/footer.md -->


### PR DESCRIPTION
Some repositories have a protected branch rule. That means our workflow won't work because commiting directly to main
is not allowed. To prevent that, the workflow will now open a PR for the changes. Rather than chancing the repo rules, updating the workflow is easier. Probably safer, too.

Other updates include only running the workflow when the README is updated. And removing the leading `/` that indicates it's a file (but it isn't). @nickcharlton [pointed it out here](https://github.com/thoughtbot/stylelint-config/pull/57#discussion_r1539021053). It must have been needed when I was testing things but it works fine without it on this [test repo](https://github.com/thoughtbot/testing-reusable-workflow).

