### PR TITLE
Add a SECURITY.md.template

### DIFF
--- a/SECURITY.md.template
+++ b/SECURITY.md.template
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+Only the the latest version of $(PROJECT_NAME) is supported at a given time. If
+you find a security issue with an older version, please try updating to the
+latest version first.
+
+If for some reason you can't update to the latest version, please let us know
+your reasons so that we can have a better understanding of your situation.
+
+## Reporting a Vulnerability
+
+For security inquiries or vulnerability reports, visit
+<https://thoughtbot.com/security>.


### PR DESCRIPTION
This adds a template for SECURITY.md. Rather than including the
reporting information directly, I've opted to link to a web page where
we have the information, along with our PGP info.
