### PR TITLE
Remove extraneous extra new line that conflicts with markdownlint

### DIFF
--- a/templates/footer.md
+++ b/templates/footer.md
@@ -11,4 +11,3 @@ We are [available for hire][hire].
 
 [community]: https://thoughtbot.com/community?utm_source=github
 [hire]: https://thoughtbot.com/hire-us?utm_source=github
-


### PR DESCRIPTION
The footer template contains an extra newline that is redundant and conflicts with markdownlint rules in the guides project.